### PR TITLE
add test "... isa 'Error::TypeTiny'"

### DIFF
--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -72,6 +72,8 @@ subtest 'negative simple' => sub {
         $args = $check->( monies => ["abc"] )
     } "... dies when passing bad values";
     
+    isa_ok( $@, 'Error::TypeTiny' );
+    
 };
 
 done_testing();


### PR DESCRIPTION
Which is automatically true.

Maybe in light off TDD, the previous test should not
have checked if it died, but if it did return this
specific exception object.