### PR TITLE
Error::TypeTiny::Validation

### DIFF
--- a/lib/Error/TypeTiny/Validation.pm
+++ b/lib/Error/TypeTiny/Validation.pm
@@ -3,6 +3,6 @@ package Error::TypeTiny::Validation;
 require Error::TypeTiny;
 our @ISA = 'Error::TypeTiny';
 
-sub errors { !!1 }
+sub errors { {} }
 
 1;

--- a/lib/Error/TypeTiny/Validation.pm
+++ b/lib/Error/TypeTiny/Validation.pm
@@ -3,4 +3,6 @@ package Error::TypeTiny::Validation;
 require Error::TypeTiny;
 our @ISA = 'Error::TypeTiny';
 
+sub errors { !!1 }
+
 1;

--- a/lib/Error/TypeTiny/Validation.pm
+++ b/lib/Error/TypeTiny/Validation.pm
@@ -1,0 +1,6 @@
+package Error::TypeTiny::Validation;
+
+require Error::TypeTiny;
+our @ISA = 'Error::TypeTiny';
+
+1;

--- a/lib/Error/TypeTiny/Validation.pm
+++ b/lib/Error/TypeTiny/Validation.pm
@@ -3,6 +3,6 @@ package Error::TypeTiny::Validation;
 require Error::TypeTiny;
 our @ISA = 'Error::TypeTiny';
 
-sub errors { {} }
+sub errors { $_[0]{errors} }
 
 1;

--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -8,12 +8,21 @@ use Type::Params ();
 use Exporter 'import';
 our @EXPORT_OK = qw/&compile_named/;
 
+use Try::Tiny;
+
 sub compile_named {
     my @checks = @_;
     my $check = Type::Params::compile_named(@checks);
     
     return sub {
-        return $check->(@_)
+        my @params = @_;
+        
+        try {
+            return $check->(@params);
+        } catch {
+            require Error::TypeTiny::Validation;
+            Error::TypeTiny::Validation->throw( );
+        };
     }
     
 }

--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -21,10 +21,13 @@ sub compile_named {
             return $check->(@params);
         } catch {
             my $error = $_;
+            my $varname = $error->varname();
+            $varname =~ s/^\$_\{"//;
+            $varname =~ s/"\}$//;
             require Error::TypeTiny::Validation;
             Error::TypeTiny::Validation->throw(
                 message => 'One or more exceptions have occurred',
-                errors  => { 'account_number' => $error },
+                errors  => { $varname => $error },
             );
         };
     }

--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -20,9 +20,11 @@ sub compile_named {
         try {
             return $check->(@params);
         } catch {
+            my $error = $_;
             require Error::TypeTiny::Validation;
             Error::TypeTiny::Validation->throw(
                 message => 'One or more exceptions have occurred',
+                errors  => { 'account_number' => $error },
             );
         };
     }

--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -21,7 +21,9 @@ sub compile_named {
             return $check->(@params);
         } catch {
             require Error::TypeTiny::Validation;
-            Error::TypeTiny::Validation->throw( );
+            Error::TypeTiny::Validation->throw(
+                message => 'One or more exceptions have occurred',
+            );
         };
     }
     

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -96,6 +96,10 @@ subtest 'error_typetiny_validation' => sub {
         "... and has errors"
     );
     
+    is( ref($exception->errors), 'HASH',
+        "... which is an HASH reference"
+    );
+    
 };
 
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -84,10 +84,11 @@ subtest 'error_typetiny_validation' => sub {
         $args = $check->( account_number => '123.456.789' )
     } "... dies when passing bad values";
     
-    isa_ok( $@, 'Error::TypeTiny::Validation' );
     my $exception = $@;
     
-    like( $@->message, qr/One or more exceptions have occurred/,
+    isa_ok( $exception, 'Error::TypeTiny::Validation' );
+    
+    like( $exception->message, qr/One or more exceptions have occurred/,
         "... And has a message about 'One or more exceptions'"
     );
     

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -86,6 +86,10 @@ subtest 'error_typetiny_validation' => sub {
     
     isa_ok( $@, 'Error::TypeTiny::Validation' );
     
+    like( $@->message, qr/One or more exceptions have occurred/,
+        "... And has a message about 'One or more exceptions'"
+    );
+    
 };
 
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -109,6 +109,10 @@ subtest 'error_typetiny_validation' => sub {
         "... and has 'Error::TypeTiny' for parameter"
     );
     
+    like( $errors->{account_number}->message, qr/123.456.789/,
+        "... and has a useful message"
+    );
+    
 };
 
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -76,4 +76,16 @@ subtest 'negative simple' => sub {
     
 };
 
+subtest 'error_typetiny_validation' => sub {
+    my $check = compile_named( account_number => Num );
+    
+    my $args;
+    dies_ok{
+        $args = $check->( account_number => '123.456.789' )
+    } "... dies when passing bad values";
+    
+    isa_ok( $@, 'Error::TypeTiny::Validation' );
+    
+};
+
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -113,6 +113,20 @@ subtest 'error_typetiny_validation' => sub {
         "... and has a useful message"
     );
     
+    my $other = compile_named( sort_code => Num );
+    throws_ok{
+        $args = $other->( sort_code => '12-34-56' )
+    } qr/One or more exceptions have occurred/,
+    "Throws exception with correct stringification";
+    
+    $errors = $@->errors;
+    cmp_deeply( $errors =>
+        {
+            sort_code => isa('Error::TypeTiny'),
+        },
+        "... and it is for another parameter"
+    );
+    
 };
 
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -85,6 +85,7 @@ subtest 'error_typetiny_validation' => sub {
     } "... dies when passing bad values";
     
     isa_ok( $@, 'Error::TypeTiny::Validation' );
+    my $exception = $@;
     
     like( $@->message, qr/One or more exceptions have occurred/,
         "... And has a message about 'One or more exceptions'"

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -92,6 +92,10 @@ subtest 'error_typetiny_validation' => sub {
         "... And has a message about 'One or more exceptions'"
     );
     
+    ok( $exception->errors,
+        "... and has errors"
+    );
+    
 };
 
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -100,6 +100,15 @@ subtest 'error_typetiny_validation' => sub {
         "... which is an HASH reference"
     );
     
+    my $errors = $exception->errors();
+    
+    cmp_deeply( $errors =>
+        {
+            account_number => isa('Error::TypeTiny'),
+        },
+        "... and has 'Error::TypeTiny' for parameter"
+    );
+    
 };
 
 done_testing();


### PR DESCRIPTION
With this merge, if one type-constraint error occurs, then it will throw the approriate error will be wrapped in a `Error::TypeTiny::Validation`.

This `Error::TypeTiny::Validation` will have an `errors` method that will return a hashref with keys for every problematic paramater.

NB... This still only works for type-constraints, and only for the first it encounters.