### PR TITLE
Unrecognized parameters

### DIFF
--- a/lib/Error/TypeTiny/UnrecognizedParameter.pm
+++ b/lib/Error/TypeTiny/UnrecognizedParameter.pm
@@ -1,0 +1,13 @@
+package Error::TypeTiny::UnrecognizedParameter;
+
+require Error::TypeTiny;
+our @ISA = 'Error::TypeTiny';
+
+sub named_param{ $_[0]->{named_param} }
+
+sub _build_message{
+    my $e = shift;
+    return "Unrecognized parameter: " . $e->named_param()
+}
+
+1;

--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -50,6 +50,8 @@ sub compile_named {
                 }
                 $errors{$check_param} = $error;
             };
+            
+            delete $params{$check_param};
         }
         
         require Error::TypeTiny::Validation;

--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -54,6 +54,14 @@ sub compile_named {
             delete $params{$check_param};
         }
         
+        foreach my $check_param ( keys %params ) {
+            require Error::TypeTiny::UnrecognizedParameter;
+            my $error = Error::TypeTiny::UnrecognizedParameter->new(
+                named_param => $check_param,
+            );
+            $errors{$check_param} = $error;
+        }
+        
         require Error::TypeTiny::Validation;
         Error::TypeTiny::Validation->throw(
             message => 'One or more exceptions have occurred',

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -180,7 +180,7 @@ subtest 'missing required parameters' => sub {
     
 };
 
-subtest 'unrecognised parameters' => sub {
+subtest 'unrecognized parameters' => sub {
     my $check = compile_named( );
     
     throws_ok{

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -180,4 +180,14 @@ subtest 'missing required parameters' => sub {
     
 };
 
+subtest 'unrecognised parameters' => sub {
+    my $check = compile_named( );
+    
+    throws_ok{
+        $check->( foo => 1, bar => 2 )
+    } qr/One or more exceptions have occurred/,
+    "Throws exception";
+    
+};
+
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -184,9 +184,18 @@ subtest 'unrecognized parameters' => sub {
     my $check = compile_named( );
     
     throws_ok{
-        $check->( foo => 1, bar => 2 )
+        $check->( foo => 1 )
     } qr/One or more exceptions have occurred/,
     "Throws exception";
+    
+    my $errors = $@->errors;
+    
+    cmp_deeply( $errors =>
+        {
+            foo => isa('Error::TypeTiny::UnrecognizedParameter'),
+        },
+        "... and contains Error::TypeTiny::UnrecognizedParameter exception"
+    );
     
 };
 


### PR DESCRIPTION
Create an `Error::TypeTiny::UnrecognizedParameter` exception for each unrecognised param, instead of one that contains all