### PR TITLE
Accept hashref as params to check

### DIFF
--- a/lib/Type/Params/Validation.pm
+++ b/lib/Type/Params/Validation.pm
@@ -22,7 +22,12 @@ sub compile_named {
         };
         return $args if defined $args;
         
-        my %params = @params; # original params
+        my %params =
+            scalar @params == 1 && ref($params[0]) eq "HASH" ?
+                %{ $params[0] }
+            :
+                @params
+        ; # original params
         my %checks = _split_compile(@checks);
         
         my %errors;

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -214,6 +214,24 @@ subtest 'accept hashref as params to check' => sub {
         "... and accepts params as a hashref too"
     );
     
+    throws_ok{
+        $check->( {foo => undef, baz => 5 } )
+    } qr/One or more exceptions have occurred/,
+    "Throws exception for a hashref that";
+    
+    my $errors = $@->errors;
+    
+    cmp_deeply( $errors =>
+        {
+            foo => isa('Error::TypeTiny::Assertion'),
+            bar => isa('Error::TypeTiny::MissingRequired'),
+            baz => isa('Error::TypeTiny::UnrecognizedParameter'),
+        },
+        "... and contains multiple exceptions"
+    );
+    # this would otherwise be an error, missing 'foo' and 'bar' and:
+    # message       "Unrecognized parameter: HASH(0x7f9b3390a2c8)"
+    
 };
 
 done_testing();

--- a/t/10_compile_named.t
+++ b/t/10_compile_named.t
@@ -199,4 +199,21 @@ subtest 'unrecognized parameters' => sub {
     
 };
 
+subtest 'accept hashref as params to check' => sub {
+    my $check = compile_named( foo => Num, bar => Num );
+    
+    cmp_deeply(
+        $check->(  foo => 3, bar => 5  ) =>
+        { foo => 3, bar => 5, },
+        "Accepts params as a hash"
+    );
+    
+    cmp_deeply(
+        $check->( {foo => 3, bar => 5} ) =>
+        { foo => 3, bar => 5, },
+        "... and accepts params as a hashref too"
+    );
+    
+};
+
 done_testing();


### PR DESCRIPTION
compile_named SHOULD accept a hashref as arguments, not only a nice list of key/value pairs.

`$check->( @_ )`, `$check->( %args }` and `$check( \%args )` SHOULD all work and all would if all params were okay etc.

However, it should report nice errors for anything that would have gone wrong, other than `"Unrecognized parameter: HASH(0x7f9b3390a2c8)"`. That would be caused because the first thing it encounters as a 'key' is the hashref.